### PR TITLE
Correct minor grammar issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![PGXN version](https://badge.fury.io/pg/pg_idx_advisor.svg)](https://badge.fury.io/pg/pg_idx_advisor)
 
-A PostgreSQL extension to analyze queries and give indexing advise.
+A PostgreSQL extension to analyze queries and give indexing advice.
 
 ## Introduction ##
 The index advisor uses the virtual index framework/support built into PG

--- a/src/idx_adviser.c
+++ b/src/idx_adviser.c
@@ -563,7 +563,7 @@ static PlannedStmt* index_adviser(	Query*			queryCopy,
 	if( SPI_finish() != SPI_OK_FINISH )
 		elog( WARNING, "IND ADV: SPI_finish failed." );
 
-	elog( DEBUG1, "IND ADV: save the advise into the table" );
+	elog( DEBUG1, "IND ADV: save the advice into the table" );
 	/* save the advise into the table */
 	if( saveCandidates )
 	{


### PR DESCRIPTION
'Advice' is a recommendation, 'advise' is a verb meaning 'to give advice', looks good other than in these two spots. Can also be corrected in project description field.
